### PR TITLE
Changed digitalIn to analogIn typo

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -75,7 +75,7 @@ Set pin mode
 
 Toggle analogIn reporting by pin
 ```
-0  toggle digitalIn reporting (0xC0-0xCF) (MIDI Program Change)
+0  toggle analogIn reporting (0xC0-0xCF) (MIDI Program Change)
 1  disable(0) / enable(non-zero)
 ```
 *As of Firmata 2.4.0, upon enabling an analog pin, the pin value should be reported to the client


### PR DESCRIPTION
I changed what I am pretty sure is a typo under Toggle analogIn reporting by pin.
It was "toggle digitalIn ..." and I changed it to "toggle analogIn..."
