### PR TITLE
add message to update the baud rate of configured serial port

### DIFF
--- a/serial.md
+++ b/serial.md
@@ -62,7 +62,7 @@ only be specified if the platform requires them to be set.
 
 ```
 0  START_SYSEX      (0xF0)
-1  SERIAL_DATA      (0x60)  // command byte
+1  SERIAL_MESSAGE   (0x60)  // command byte
 2  SERIAL_CONFIG    (0x10)  // OR with port (0x11 = SERIAL_CONFIG | HW_SERIAL1)
 3  baud             (bits 0 - 6)
 4  baud             (bits 7 - 13)
@@ -80,7 +80,7 @@ Receive serial data from Firmata client, reassemble and write for each byte rece
 
 ```
 0  START_SYSEX      (0xF0)
-1  SERIAL_DATA      (0x60)
+1  SERIAL_MESSAGE   (0x60)
 2  SERIAL_WRITE     (0x20) // OR with port (0x21 = SERIAL_WRITE | HW_SERIAL1)
 3  data 0           (LSB)
 4  data 0           (MSB)
@@ -102,7 +102,7 @@ specified by `maxBytesToRead` then the lesser number of bytes will be returned.
 
 ```
 0  START_SYSEX        (0xF0)
-1  SERIAL_DATA        (0x60)
+1  SERIAL_MESSAGE     (0x60)
 2  SERIAL_READ        (0x30) // OR with port (0x31 = SERIAL_READ | HW_SERIAL1)
 3  SERIAL_READ_MODE   (0x00) // 0x00 => read continuously, 0x01 => stop reading
 4  maxBytesToRead     (lsb) [optional]
@@ -118,7 +118,7 @@ Sent in response to a SERIAL_READ event or on each iteration of the reporting lo
 
 ```
 0  START_SYSEX        (0xF0)
-1  SERIAL_DATA        (0x60)
+1  SERIAL_MESSAGE     (0x60)
 2  SERIAL_REPLY       (0x40) // OR with port (0x41 = SERIAL_REPLY | HW_SERIAL1)
 3  data 0             (LSB)
 4  data 0             (MSB)
@@ -135,7 +135,7 @@ reopen it.
 
 ```
 0  START_SYSEX        (0xF0)
-1  SERIAL_DATA        (0x60)
+1  SERIAL_MESSAGE     (0x60)
 2  SERIAL_CLOSE       (0x50) // OR with port (0x51 = SERIAL_CLOSE | HW_SERIAL1)
 3  END_SYSEX          (0xF7)
 ```
@@ -153,7 +153,7 @@ cases.
 
 ```
 0  START_SYSEX        (0xF0)
-1  SERIAL_DATA        (0x60)
+1  SERIAL_MESSAGE     (0x60)
 2  SERIAL_FLUSH       (0x60) // OR with port (0x61 = SERIAL_FLUSH | HW_SERIAL1)
 3  END_SYSEX          (0xF7)
 ```
@@ -165,7 +165,21 @@ other platforms.
 
 ```
 0  START_SYSEX        (0xF0)
-1  SERIAL_DATA        (0x60)
+1  SERIAL_MESSAGE     (0x60)
 2  SERIAL_LISTEN      (0x70) // OR with port to switch to (0x79 = switch to SW_SERIAL1)
 3  END_SYSEX          (0xF7)
+```
+
+### Serial Update Baud
+
+Update the baud rate on a configured serial port.
+
+```
+0  START_SYSEX        (0xF0)
+1  SERIAL_MESSAGE     (0x60)
+2  SERIAL_UPDATE_BAUD (0x80) // OR with port to switch to (0x89 = SERIAL_UPDATE_BAUD | SW_SERIAL1)
+3  baud               (bits 0 - 6)
+4  baud               (bits 7 - 13)
+5  baud               (bits 14 - 20) // need to send 3 bytes for baud even if value is < 14 bits
+6  END_SYSEX          (0xF7)
 ```

--- a/serial.md
+++ b/serial.md
@@ -7,7 +7,8 @@ Sample implementation code for Arduino is available [here](https://github.com/fi
 
 A client implementation can be found [here](https://github.com/jgautier/firmata/blob/master/lib/firmata.js).
 
-Added in version 2.5.0
+Added in Firmata protocol version 2.5.0
+Updated in version 2.6.0 to add `SERIAL_UPDATE_BAUD`
 
 ## Constants
 
@@ -174,12 +175,16 @@ other platforms.
 
 Update the baud rate on a configured serial port.
 
+Note: Due to an oversight in the initial version of the `SERIAL_MESSAGE` format, `SERIAL_EXTEND`
+is necessary to add additional serial commands.
+
 ```
 0  START_SYSEX        (0xF0)
 1  SERIAL_MESSAGE     (0x60)
-2  SERIAL_UPDATE_BAUD (0x80) // OR with port to switch to (0x89 = SERIAL_UPDATE_BAUD | SW_SERIAL1)
-3  baud               (bits 0 - 6)
-4  baud               (bits 7 - 13)
-5  baud               (bits 14 - 20) // need to send 3 bytes for baud even if value is < 14 bits
-6  END_SYSEX          (0xF7)
+2  SERIAL_EXTEND      (0x00) // OR with portId (0x09 = SERIAL_EXTEND | SW_SERIAL1)
+3  SERIAL_UPDATE_BAUD (0x01) // up to 127 extended commands
+4  baud               (bits 0 - 6)
+5  baud               (bits 7 - 13)
+6  baud               (bits 14 - 20) // need to send 3 bytes for baud even if value is < 14 bits
+7  END_SYSEX          (0xF7)
 ```


### PR DESCRIPTION
Proposal to add a message to update the baud rate of a configured serial port. This is useful for applications where the user needs to change the baud rate to something more manageable. A specific example is the need to drop the baud rate for a device that defaults at 115200 ( which is not reliable for SoftwareSerial in Firmata) down to a lower rate such as 9600.
