### PR TITLE
Proposal: Add a general device control API

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -123,6 +123,7 @@ RESERVED               0x00-0x0F // The first 16 bytes are reserved for custom c
                                  // (provide link to section describing custom commands)
 SERIAL_MESSAGE              0x60 // communicate with serial devices, including other boards
 ENCODER_DATA                0x61 // reply with encoders current positions
+REPORT_FEATURES             0x62 // report the features supported by this firmware (Servo, I2C, etc)
 ANALOG_MAPPING_QUERY        0x69 // ask for mapping of analog to pin numbers
 ANALOG_MAPPING_RESPONSE     0x6A // reply with mapping info
 CAPABILITY_QUERY            0x6B // ask for supported modes and resolution of all pins
@@ -169,6 +170,75 @@ Receive Firmware Name and Version (after query)
 5  second 7-bits of firmware name
 ... for as many bytes as it needs
 N  END_SYSEX         (0xF7)
+```
+
+Report features
+---
+
+Report standard and contributed features supported by the firmware and the version of each feature.
+
+As of Firmata version 2.6.0 there are now 3 types of features:
+1. Core features (those defined in this protocol.md file)
+2. Standard features (I2C, Serial)
+3. Contributed features (Encoder, OneWire, Stepper, Servo, Scheduler)
+
+*Core features* are composed of both *Core Direct* messages such as `SystemReset(0xFF)`,
+`ReportVersion(0xF9)`, `ReportDigital(0xD0)`, `ReportAnalog(0xE0)`, etc and *Core Sysex* messages
+such as `ReportFirmware(0x79)`, `ExtendedAnalog(0x6F)`, `StringData(0x71)`, `CapabilityQuery(0x68)`,
+etc.
+
+*Standard features* are typically pin-level features of the microcontroller board such as I2C, SPI,
+UART, CAN, etc.
+
+*Contributed features* define generic (Servo, Stepper, OneWire) or device-specific (DHT11, NeoPixel)
+interfaces or other services (Scheduler) that are not integral to the functionality of the
+microcontroller itself or part of the core logic.
+
+The *core* protocol version is defined at the top of this file and covers the features specified
+in this document. The core version covers the Core Direct and Core Sysex messages. If any change is
+made to those message, the core version needs to be incremented appropriately.
+
+As of Firmata v2.6.0, standard and contributed features have their own version, beginning at v1.0.0
+for each feature that was in use prior to v2.6.0 and beginning at v0.1.0 for any new features added
+since core v2.6.0. The feature bugfix version is not reported but it should be maintained.
+
+This enables changes to be made to individual features without needing to change the core version.
+It also enables multiple variations of a feature to coexist simultaneously, for example a new I2C
+feature could be added that enables the ability to use multiple I2C ports rather than a single
+version. That enables Firmata client libraries to adapt the new I2C interface while deprecating the
+old one without breaking client libraries that don't update to the new version. Both versions would
+use the same pin mode but have different command identifiers.
+
+**Query supported standard and contributed features.**
+```
+0  START_SYSEX                (0xF0)
+1  REPORT_FEATURES            (0x62)
+2  REPORT_FEATURES_QUERY      (0x00)
+3  END_SYSEX                  (0xF7)
+```
+
+**Supported standard and contributes features query response.**
+
+The `FEATURE_ID` is 2 bytes for scalability (composed as a pair of two 7-bit bytes rather than a
+single number). Features existing prior core protocol v2.6.0 should assign their existing 1 byte
+subcommand to the LSB of the ID and set the MSB to 0. For existing features that don't have a single
+subcommand byte (I2C), the CONFIG subcommand should be the identifying subcommand, so for I2C the
+ID would be: `0x0078`. This also means the the LSB in the range `0x50 - 0x7F` is reserved so new new
+IDs cannot be allocated within this range: `0xXX50 - 0xXX7F`.
+```
+0  START_SYSEX                (0xF0)
+1  REPORT_FEATURES            (0x62)
+2  REPORT_FEATURES_RESPONSE   (0x01)
+3  1st FEATURE_ID LSB         The subcommand byte allocated to the feature
+4  1st FEATURE_ID MSB         use 2 bytes to ensure scalability
+5  1st FEATURE_MAJOR_VERSION  (0-127)
+6  1st FEATURE_MINOR_VERSION  (0-127)
+7  2nd FEATURE_ID LSB
+8  2nd FEATURE_ID MSB
+9  2nd FEATURE_MAJOR_VERSION  (0-127)
+10 2nd FEATURE_MINOR_VERSION  (0-127)
+... for all supported features
+n  END_SYSEX                  (0xF7)
 ```
 
 Extended Analog


### PR DESCRIPTION
This proposal comes out of a [discussion](https://github.com/firmata/protocol/pull/40) I had with @finson regarding the need to separate the concepts of "core" and non-core features and their respective versions. It would also alleviate much of the "version hell" I've been experiencing lately.

The first thing this proposal does is establish 3 types of Firmata features (they are described in more detail in the PR):
1. Core features
2. Standard features
3. Contributed features

Core features would fall under the core protocol version, which is currently v2.5.1 but if this PR gets merged it will be v2.6.0. The idea is that for a Firmata client to be compatible with Firmata v2.6.0 (for the purpose of this example) it would have to implement all of the core features. The standard and contributed features would be add-ons.

Each standard and contributed feature would have its own version. For features existing prior to Firmata v2.6.0 the version number would start at `v1.0.0`, for any new features the version number should start at `v0.1.0`.

Beginning with v2.6.0, a Firmata client library could check if the protocol version is at least v2.6.0 and if so, issue a `REPORT_FEATURES` command and receive a response that lists all of the features implemented by the firmware. For and Arduino-compatible board running StandardFirmata, this would return the features `SERVO` and `I2C`, StandardFirmataPlus would return `SERVO`, `I2C` and `SERIAL`. For ConfigurableFirmata it would reflect the user's configuration.

This enables features to evolve independently of the core protocol. It also enables multiple versions of a feature to exist, such as a new version of I2C that supports multiple I2C ports on a board that can exist alongside of the legacy implementation that only supports a single port (a particular firmware would only implement one of the 2 versions, but the client would be able to query which version is implemented... as long as the core protocol version is v2.6.0 or higher).

One complexity (and this is getting off topic a bit) in this proposal is that I want to report the feature by a 14-bit ID value. All existing features have a 7 bit subcommand. This poses a problem for the existing features. My idea here (and it may be a bit confusing but I haven't thought of a better alternative) is to set the existing subcommand byte as the LSB in the ID, then set the MSB to 0. What makes this complicated is that bans any ID from having an LSB value in the range of `0x50 - 0x7F` (I could possibly get away with `0x60 - 0x7F` but it may be useful to leave some values available for new core features). This still leaves a wide range of unallocated IDs (much more than sticking with the 7-bit identifier that is running out) but the prohibited LSB range may be confusing. I'm open to other suggestions as well.

One ambiguity in this proposal is where to classify `SCHEDULER`. By it's nature I think it should really be a core feature, but it has rarely been used. It may have a low enough use case that it belongs in the _contributed features_ category (where I put it in this initial proposal).
