### PR TITLE
[PLEASE REVIEW] revised definition for Serial feature

### DIFF
--- a/serial.md
+++ b/serial.md
@@ -63,13 +63,14 @@ only be specified if the platform requires them to be set.
 ```
 0  START_SYSEX      (0xF0)
 1  SERIAL_DATA      (0x60)  // command byte
-2  SERIAL_CONFIG    (0x10)  // OR with port (0x11 = SERIAL_CONFIG | HW_SERIAL1)
-3  baud             (bits 0 - 6)
-4  baud             (bits 7 - 13)
-5  baud             (bits 14 - 20) // need to send 3 bytes for baud even if value is < 14 bits
-6  rxPin            (0-127) [optional] // only set if platform requires RX pin number
-7  txPin            (0-127) [optional] // only set if platform requires TX pin number
-6|8 END_SYSEX      (0xF7)
+2  SERIAL_CONFIG    (0x10)
+3  portId           (any of the defined port IDs such as HW_SERIAL1, SW_SERIAL0)
+4  baud             (bits 0 - 6)
+5  baud             (bits 7 - 13)
+6  baud             (bits 14 - 20) // need to send 3 bytes for baud even if value is < 14 bits
+7  rxPin            (0-127) [optional] // only set if platform requires RX pin number
+8  txPin            (0-127) [optional] // only set if platform requires TX pin number
+7|8 END_SYSEX       (0xF7)
 ```
 
 ### Serial Write
@@ -81,11 +82,12 @@ Receive serial data from Firmata client, reassemble and write for each byte rece
 ```
 0  START_SYSEX      (0xF0)
 1  SERIAL_DATA      (0x60)
-2  SERIAL_WRITE     (0x20) // OR with port (0x21 = SERIAL_WRITE | HW_SERIAL1)
-3  data 0           (LSB)
-4  data 0           (MSB)
-5  data 1           (LSB)
-6  data 1           (MSB)
+2  SERIAL_WRITE     (0x20)
+3  portId           (any of the defined port IDs such as HW_SERIAL1, SW_SERIAL0)
+4  data 0           (LSB)
+5  data 0           (MSB)
+6  data 1           (LSB)
+7  data 1           (MSB)
 ...                 // up to max buffer - 5
 n  END_SYSEX        (0xF7)
 ```
@@ -103,8 +105,8 @@ specified by `maxBytesToRead` then the lesser number of bytes will be returned.
 ```
 0  START_SYSEX        (0xF0)
 1  SERIAL_DATA        (0x60)
-2  SERIAL_READ        (0x30) // OR with port (0x31 = SERIAL_READ | HW_SERIAL1)
-3  SERIAL_READ_MODE   (0x00) // 0x00 => read continuously, 0x01 => stop reading
+2  SERIAL_READ        (0x30) // OR with read mode: 0x30 => read continuously, 0x31 => stop reading
+3  portId             (any of the defined port IDs such as HW_SERIAL1, SW_SERIAL0)
 4  maxBytesToRead     (lsb) [optional]
 5  maxBytesToRead     (msb) [optional]
 4|6 END_SYSEX         (0xF7)
@@ -119,11 +121,12 @@ Sent in response to a SERIAL_READ event or on each iteration of the reporting lo
 ```
 0  START_SYSEX        (0xF0)
 1  SERIAL_DATA        (0x60)
-2  SERIAL_REPLY       (0x40) // OR with port (0x41 = SERIAL_REPLY | HW_SERIAL1)
-3  data 0             (LSB)
-4  data 0             (MSB)
-3  data 1             (LSB)
-4  data 1             (MSB)
+2  SERIAL_REPLY       (0x40)
+3  portId             (any of the defined port IDs such as HW_SERIAL1, SW_SERIAL0)
+4  data 0             (LSB)
+5  data 0             (MSB)
+6  data 1             (LSB)
+7  data 1             (MSB)
 ...                   // up to max buffer - 5
 n  END_SYSEX          (0xF7)
 ```
@@ -136,8 +139,9 @@ reopen it.
 ```
 0  START_SYSEX        (0xF0)
 1  SERIAL_DATA        (0x60)
-2  SERIAL_CLOSE       (0x50) // OR with port (0x51 = SERIAL_CLOSE | HW_SERIAL1)
-3  END_SYSEX          (0xF7)
+2  SERIAL_CLOSE       (0x50)
+3  portId             (any of the defined port IDs such as HW_SERIAL1, SW_SERIAL0)
+4  END_SYSEX          (0xF7)
 ```
 
 ### Serial Flush
@@ -154,8 +158,9 @@ cases.
 ```
 0  START_SYSEX        (0xF0)
 1  SERIAL_DATA        (0x60)
-2  SERIAL_FLUSH       (0x60) // OR with port (0x61 = SERIAL_FLUSH | HW_SERIAL1)
-3  END_SYSEX          (0xF7)
+2  SERIAL_FLUSH       (0x60)
+3  portId             (any of the defined port IDs such as HW_SERIAL1, SW_SERIAL0)
+4  END_SYSEX          (0xF7)
 ```
 
 ### Serial Listen
@@ -166,6 +171,22 @@ other platforms.
 ```
 0  START_SYSEX        (0xF0)
 1  SERIAL_DATA        (0x60)
-2  SERIAL_LISTEN      (0x70) // OR with port to switch to (0x79 = switch to SW_SERIAL1)
-3  END_SYSEX          (0xF7)
+2  SERIAL_LISTEN      (0x70)
+3  portId             (any of the defined software serial IDs such as SW_SERIAL0)
+4  END_SYSEX          (0xF7)
+```
+
+### Serial Update Baud
+
+Update the baud rate on a configured serial port.
+
+```
+0  START_SYSEX        (0xF0)
+1  SERIAL_MESSAGE     (0x60)
+2  SERIAL_UPDATE_BAUD (0x01)
+3  portId             (any of the defined port IDs such as HW_SERIAL1, SW_SERIAL0)
+4  baud               (bits 0 - 6)
+5  baud               (bits 7 - 13)
+6  baud               (bits 14 - 20) // need to send 3 bytes for baud even if value is < 14 bits
+7  END_SYSEX          (0xF7)
 ```


### PR DESCRIPTION
In short, I made a mistake in the original version of the Serial feature protocol definition that limited it to 8 modes (`CONFIG`, `READ`, `WRITE`, `REPLY`, `CLOSE`, `FLUSH`, `LISTEN` and one slot available `0x00`). While I have a plan that can still enable additional modes to be added to the original definition, it's not necessarily pretty. Therefore, for the purpose of discussion I've drafted a revised definition for the Serial feature.

**The good**
This feature has only been available for a couple of months and to my knowledge has only been implemented in 3 Firmata client libraries (firmata.js, perl-firmata and Breakout.js) so changing it now would be better than later. Changing the feature protocol definition would not break firmata.js or Breakout.js since the public facing APIs could remain unchanged. I'm not sure about perl-firmata however.

Fixing the definition now enables it to scale cleanly moving forward.

**The bad**
Changing it would be a breaking change because 2 versions of Firmata exist with the original definition and implementation (Firmata v2.5.0 and v2.5.1). Firmata v2.5.0 is included with the latest Arduino IDE download. Given this it may not be wise to change the definition now even if this feature is not yet widely in use.

**The ugly**
If a breaking change is made, any existing Firmata client implementation that added support for the Serial feature would likely need to detect the Firmata protocol version implemented by the firmware and respond appropriately. I'm also not sure how often Arduino pulls Firmata into the IDE so that may leave existing users with v2.5.0 for some time and is an issue if they don't update Firmata via the Library Manager.

**The alternative**
The alternative to the proposal in this PR is to add additional features via a `SERIAL_EXTEND` mode (it makes use of the currently unused `0x00` value). It keeps the existing modes and enables adding new modes after the SERIAL_EXTEND byte. It would enable adding up to 127 additional modes (although I'd only expect a handful to ever be added). It looks like this (using SERIAL_UPDATE_BAUD as an example):

```
0  START_SYSEX        (0xF0)
1  SERIAL_MESSAGE     (0x60)
2  SERIAL_EXTEND      (0x00) // OR with portId (0x09 = SERIAL_EXTEND | SW_SERIAL1)
3  SERIAL_UPDATE_BAUD (0x01) // up to 127 extended commands
4  baud               (bits 0 - 6)
5  baud               (bits 7 - 13)
6  baud               (bits 14 - 20) // need to send 3 bytes for baud even if value is < 14 bits
7  END_SYSEX          (0xF7)
```

It would obviously be cleaner to have kept the mode and ID (both packed into byte 2 in the [original definition](https://github.com/firmata/protocol/blob/master/serial.md)) separate from the beginning as is addressed in this PR. However given "the bad" and "the ugly" it may be better to go with the alternative until a breaking change can be made (Firmata v3.0 or if/when individual [features get their own versioning scheme](https://github.com/firmata/protocol/pull/47)).