### PR TITLE
Fix a minor problem

### DIFF
--- a/proposals/serial-2.0-proposal.md
+++ b/proposals/serial-2.0-proposal.md
@@ -1,4 +1,4 @@
-#Serial 2.0 (Proposal)
+# Serial 2.0 (Proposal)
 
 Current version: 2.0.0
 


### PR DESCRIPTION
This PR fixes a minor problem in proposals/serial-2.0-proposal.md where 
```md
# Serial 2.0 (Proposal)
``` 
was 
```md
#Serial 2.0 (Proposal)
```