### PR TITLE
Fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ There are several client libraries. These are libraries that implement the Firma
   * [https://github.com/reapzor/FiloFirmata]
 * .NET
   * [https://github.com/SolidSoils/Arduino]
-  * [http://www.imagitronics.org/projects/firmatanet/]
   * [https://github.com/wbadry/FirmataCSharpClientClass]
 * Flash/AS3
   * [http://funnel.cc]

--- a/feature-registry.md
+++ b/feature-registry.md
@@ -62,7 +62,7 @@ Each feature should be documented in a markdown file and versioned independently
 | 5DH         | RCINPUT_DATA                       | [rcswitch-proposal.md](https://github.com/firmata/protocol/blob/master/proposals/rcswitch-proposal.md) | proposed |
 | 5EH         | DEVICE_QUERY                       | [proposal](https://github.com/finson-release/Luni/blob/master/extras/v0.9/v0.8-device-driver-C-firmata-messages.md) | proposed |
 | 5FH         | DEVICE_RESPONSE                    | [proposal](https://github.com/finson-release/Luni/blob/master/extras/v0.9/v0.8-device-driver-C-firmata-messages.md) | proposed |
-| 60H         | SERIAL_DATA (1.0)                  | [serial-1.0.md](https://github.com/firmata/protocol/blob/master/serial.md) | current |
+| 60H         | SERIAL_DATA (1.0)                  | [serial-1.0.md](https://github.com/firmata/protocol/blob/master/serial-1.0.md) | current |
 | 61H         | ENCODER_DATA                       | [encoder.md](https://github.com/firmata/protocol/blob/master/encoder.md) | current |
 | 62H         | ACCELSTEPPER_DATA                  | [accelStepperFirmata.md](https://github.com/firmata/protocol/blob/master/accelStepperFirmata.md) | current |
 | 67H         | SERIAL_DATA (2.0)                  | [proposal](https://github.com/firmata/protocol/blob/master/proposals/serial-2.0-proposal.md) | proposed |

--- a/onewire.md
+++ b/onewire.md
@@ -25,7 +25,7 @@ Added in Firmata protocol version 2.4.0.
 
 ### Compatible client librairies
 * [perl-firmata](https://github.com/ntruchsess/perl-firmata)
-* [node-firmata](https://github.com/jgautier/firmata/blob/master/lib/firmata.js)
+* [node-firmata](https://github.com/firmata/firmata.js)
 
 
 ### Protocol details

--- a/protocol.md
+++ b/protocol.md
@@ -229,7 +229,7 @@ INPUT_PULLUP       (0x0B)
 The resolution byte serves a couple of different purpose:
 
 1. The original purpose was to define the resolution for analog input, pwm, servo and other modes that define a specific resolution (such as 10-bit for analog).
-2. The resolution byte has been adapted for another purpose for Serial/UART pins, it defines if the pin is RX or TX and which UART it belongs to. [RX0](https://github.com/firmata/protocol/blob/master/serial.md#serial-pin-capability-response) is the RX pin of UART0 (Serial on an Arduino for example), TX1 if the TX pin of UART1 (Serial1 on an Arduino).
+2. The resolution byte has been adapted for another purpose for Serial/UART pins, it defines if the pin is RX or TX and which UART it belongs to. [RX0](https://github.com/firmata/protocol/blob/master/serial-1.0.md#serial-pin-capability-response) is the RX pin of UART0 (Serial on an Arduino for example), TX1 if the TX pin of UART1 (Serial1 on an Arduino).
 
 Modes utilizing the resolution byte as resolution data:
 ```
@@ -244,7 +244,7 @@ INPUT_PULLUP       (0x0B) // resolution is 1 (binary)
 
 Modes utilizing the resolution byte to define type of pin:
 ```
-SERIAL             (0x0A) // See description in [serial.md](https://github.com/firmata/protocol/blob/master/serial.md#serial-pin-capability-response)
+SERIAL             (0x0A) // See description in [serial.md](https://github.com/firmata/protocol/blob/master/serial-1.0.md#serial-pin-capability-response)
 // also to be added to I2C in the future to define SCL and SDA pins
 ```
 

--- a/revisions.md
+++ b/revisions.md
@@ -9,7 +9,7 @@
 
 ## Version 2.5.0 - November 7th, 2015
 
-- Added [Serial feature](https://github.com/firmata/protocol/blob/master/serial.md) for interfacing with serial devices via hardware or software serial.
+- Added [Serial feature](https://github.com/firmata/protocol/blob/master/serial-1.0.md) for interfacing with serial devices via hardware or software serial.
 - Added ability to set the value of a pin by sending a single pin value instead of a port value. See 'set digital pin value' in [protocol.md](https://github.com/firmata/protocol/blob/master/protocol.md#message-types) for details.
 
 ## Version 2.4.0 - December 2014

--- a/serial-1.0.md
+++ b/serial-1.0.md
@@ -5,7 +5,7 @@ used simultaneously (depending on restrictions of a given microcontroller board'
 
 Sample implementation code for Arduino is available [here](https://github.com/firmata/arduino/blob/master/examples/StandardFirmataPlus/StandardFirmataPlus.ino).
 
-A client implementation can be found [here](https://github.com/jgautier/firmata/blob/master/lib/firmata.js).
+A client implementation can be found [here](https://github.com/firmata/firmata.js).
 
 Added in Firmata protocol version 2.5.0
 


### PR DESCRIPTION
I had a script crawl through all http(s) links in the protocol repo, and found several broken ones. I updated most of them with the new locations. The only one that seems to be dead for good is the one pointing to Firmata.NET library at imagitronics, so I removed it.