### PR TITLE
Added diozero-provider-firmata

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ There are several client libraries. These are libraries that implement the Firma
   * [https://github.com/4ntoine/Firmata]
   * [https://github.com/kurbatov/firmata4j]
   * [https://github.com/reapzor/FiloFirmata]
+  * [https://github.com/mattjlewis/diozero/tree/main/diozero-provider-firmata]
 * .NET
   * [https://github.com/SolidSoils/Arduino]
   * [https://github.com/dotnet/iot]

--- a/scheduler.md
+++ b/scheduler.md
@@ -17,6 +17,7 @@ Added in Firmata protocol version 2.4.0.
 
 ### Compatible client librairies
 * [perl-firmata](https://github.com/ntruchsess/perl-firmata)
+* [diozero-provider-firmata](https://github.com/mattjlewis/diozero/tree/main/diozero-provider-firmata)
 
 
 ### Protocol details


### PR DESCRIPTION
Standalone Java Firmata adapter that is incorporated into [diozero](https://www.diozero.com) as a pluggable provider. Supports all core features + I2C + Scheduler.