### PR TITLE
Add transaction scoping for I2C requests

### DIFF
--- a/i2c.md
+++ b/i2c.md
@@ -7,6 +7,8 @@ Added in Firmata protocol version 2.1.0.
 ### I2C read/write request
 
 Updated in Firmata 2.5.1 to enable setting auto-restart by setting bit 6 of byte 3.
+Updated in Frimata 2.12 to enable transaction control in 7 bit mode. For boards with long error timeouts
+(e.g. ESP32 with recent firmware), this ensures that replies can be correctly linked to their requests.
 
 ```
 0  START_SYSEX (0xF0)
@@ -17,7 +19,7 @@ Updated in Firmata 2.5.1 to enable setting auto-restart by setting bit 6 of byte
      {bit 6: auto restart transmission, 0 = stop (default), 1 = restart}
      {bit 5: address mode, 1 = 10-bit mode}
      {bits 4-3: read/write, 00 = write, 01 = read once, 10 = read continuously, 11 = stop reading}
-     {bits 2-0: slave address MSB in 10-bit mode, not used in 7-bit mode}
+     {bits 2-0: slave address MSB in 10-bit mode, transaction sequence number in 7-bit mode}
 4  data 0 (LSB)
 5  data 0 (MSB)
 6  data 1 (LSB)
@@ -41,7 +43,7 @@ end read continuous mode for that particular device.
 0  START_SYSEX (0xF0)
 1  I2C_REPLY (0x77)
 2  slave address (LSB)
-3  slave address (MSB)
+3  slave address (MSB). Bits 0-2 return the transaction sequence from the request in 7 bit mode.
 4  register (LSB)
 5  register (MSB)
 6  data 0 (LSB)


### PR DESCRIPTION
This prevents problems in case of long timeouts. If the host decided that
an I2C request timed out but the board after that still sent a reply,
the application would get confused because it could receive a reply not
matching its latest request.