### PR TITLE
Clarify analog channel numbering

### DIFF
--- a/feature-registry.md
+++ b/feature-registry.md
@@ -29,7 +29,7 @@ Firmata firmware should report the current protocol version (using the [protocol
 | 00H         | EXTENDED_ID                          | proposed   |
 | 01H - 0FH   | *Reserved for user features*         | n/a        |
 | 63H         | [REPORT_DIGTIAL_PIN - proposal](https://github.com/firmata/protocol/issues/68#issuecomment-257105540) | proposed |
-| 64H         | [EXTENDED_REPORT_ANALOG - proposal](https://github.com/firmata/protocol/issues/68#issuecomment-258748963) | proposed |
+| 64H         | [EXTENDED_REPORT_ANALOG](https://github.com/firmata/protocol/issues/68#issuecomment-258748963) | beta |
 | 65H         | [REPORT_FEATURES - proposal](https://github.com/firmata/protocol/issues/41) | proposed |
 | 69H         | [ANALOG_MAPPING_QUERY](https://github.com/firmata/protocol/blob/master/protocol.md#analog-mapping-query) | current |
 | 6AH         | [ANALOG_MAPPING_RESPONSE](https://github.com/firmata/protocol/blob/master/protocol.md#analog-mapping-query) | current |

--- a/feature-registry.md
+++ b/feature-registry.md
@@ -31,6 +31,7 @@ Firmata firmware should report the current protocol version (using the [protocol
 | 63H         | [REPORT_DIGTIAL_PIN - proposal](https://github.com/firmata/protocol/issues/68#issuecomment-257105540) | proposed |
 | 64H         | [EXTENDED_REPORT_ANALOG](https://github.com/firmata/protocol/issues/68#issuecomment-258748963) | beta |
 | 65H         | [REPORT_FEATURES - proposal](https://github.com/firmata/protocol/issues/41) | proposed |
+| 66H         | [SYSTEM_VARIABLES - proposal](https://github.com/firmata/protocol/issues/144) | proposed |
 | 69H         | [ANALOG_MAPPING_QUERY](https://github.com/firmata/protocol/blob/master/protocol.md#analog-mapping-query) | current |
 | 6AH         | [ANALOG_MAPPING_RESPONSE](https://github.com/firmata/protocol/blob/master/protocol.md#analog-mapping-query) | current |
 | 6BH         | [CAPABILITY_QUERY](https://github.com/firmata/protocol/blob/master/protocol.md#capability-query) | current |

--- a/protocol.md
+++ b/protocol.md
@@ -20,7 +20,7 @@ differently.
 | --------------------- | ------- | ------------ | ------------------- | --------------- |
 | analog I/O message    | 0xE0    | pin #        | LSB(bits 0-6)       | MSB(bits 7-13)  |
 | digital I/O message   | 0x90    | port         | LSB(bits 0-6)       | MSB(bits 7-13)  |
-| report analog pin     | 0xC0    | pin #        | disable/enable(0/1) | - n/a -         |
+| report analog pin     | 0xC0    | analog Ch#   | disable/enable(0/1) | - n/a -         |
 | report digital port   | 0xD0    | port         | disable/enable(0/1) | - n/a -         |
 |                       |         |              |                     |                 |
 | start sysex           | 0xF0    |              |                     |                 |
@@ -49,7 +49,8 @@ Two byte digital data format, second nibble of byte 0 gives the port number (eg 
 2  digital pin 7 bitmask
 ```
 
-Analog 14-bit data format
+Analog 14-bit data format. For analog input, the Arduino Axx format is used. Therefore argument value 0 means A0, argument value 
+1 means A1, etc. On an Arduino Uno, A0 is equal to physical pin 14. So to enable analog reporting on A1, send `0xF4 0x0E 0x03` (SET_PIN_MODE, 14, ANALOG) followed by `0xC1 0x01` (REPORT_ANALOG, enable). The mapping between physical pins and analog channels is provided by the ANALOG_MAPPING message. There are boards where the numbering is not continuous, so don't expect that if A0 and A5 exist, A1 does as well. Neither can you expect that if A0 = pin 10, A1 is pin 11. 
 ```
 0  analog pin, 0xE0-0xEF, (MIDI Pitch Wheel)
 1  analog least significant 7 bits
@@ -79,7 +80,7 @@ Set digital pin value (added in v2.5)
 2  value (LOW/HIGH, 0/1)
 ```
 
-Toggle analogIn reporting by pin
+Toggle analogIn reporting by analog pin number (see above for numbering scheme)
 ```
 0  toggle analogIn reporting (0xC0-0xCF) (MIDI Program Change)
 1  disable(0) / enable(non-zero)

--- a/protocol.md
+++ b/protocol.md
@@ -168,7 +168,9 @@ Extended Analog
 
 As an alternative to the normal analog message, this extended version allows
 addressing beyond pin 15 and supports sending analog values with any number of
-bits. The number of data bits is inferred by the length of the message. 
+bits. The number of data bits is inferred by the length of the message. Starting
+with protocol version 2.7, the maximum number of bits for the value is 32 (encoded
+in 5 octets). 
 
 This message is originally intend for configuring PWM outputs. When the 
 EXTENDED_REPORT_ANALOG message is used, this message is also used in

--- a/protocol.md
+++ b/protocol.md
@@ -168,7 +168,11 @@ Extended Analog
 
 As an alternative to the normal analog message, this extended version allows
 addressing beyond pin 15 and supports sending analog values with any number of
-bits. The number of data bits is inferred by the length of the message.
+bits. The number of data bits is inferred by the length of the message. 
+
+This message is originally intend for configuring PWM outputs. When the 
+EXTENDED_REPORT_ANALOG message is used, this message is also used in
+reporting changes to analog inputs for analog channels > 15.
 
 ```
 0  START_SYSEX              (0xF0)

--- a/revisions.md
+++ b/revisions.md
@@ -1,3 +1,5 @@
+This document lists relevant changes to the protocol versions.
+
 ## Version 2.7 - April 10th, 2023
 
 - EXTENDED_REPORT_ANALOG moved from proposed to beta, to support analog channels A16 and up

--- a/revisions.md
+++ b/revisions.md
@@ -1,3 +1,9 @@
+## Version 2.7 - April 10th, 2023
+
+- EXTENDED_REPORT_ANALOG moved from proposed to beta, to support analog channels A16 and up
+- EXTENDED_ANALOG message is used to report changes for analog channels A16 and up
+- Clarified documentation with respect to the definition of "Analog Pin"
+
 ## Version 2.6.1 - July 4th, 2021
 
 - Moved SPI from proposed to beta


### PR DESCRIPTION
The documentation needs a bit clarification about how analog input channels work. I got quite confused as to how the Axx map to the physical pins. This is particularly important for boards such as the ESP32, where the analog channels are not continuous. 